### PR TITLE
fix: docker compose service name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,4 @@ export BUILDKIT_PROGRESS=plain
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-docker compose -f $SCRIPT_DIR/docker-compose.yml build 
+docker compose -f $SCRIPT_DIR/docker-compose.yml build --no-cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  ros-piper:
+  ros-piper-ros:
     image: ghcr.io/rosblox/ros-piper:humble
     build:
       context: .


### PR DESCRIPTION
When service name is `ros-piper`

it results in:
`$ ./run.sh
access control disabled, clients can connect from any host
WARN[0000] The "HOST_UID" variable is not set. Defaulting to a blank string. 
no such service: ros-piper-ros` 